### PR TITLE
fix issue with last docker compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Configuration and tooling for a `docker-compose`-based Coog deployment
     - [Purge logs](#purge-logs)
     - [Deploying on multiple IPs at once](#deploying-on-multiple-ips-at-once)
     - [B2C docker-compose files](#b2c-docker-compose-files)
+    - [Failed to load - no such file or directory](#failed-to-load)
 
 <!-- /TOC -->
 
@@ -539,3 +540,15 @@ CUSTOM_B2C_FRONTEND_BUILD_VOLUME=
 ```
 
 It only needs to be persistent when containers are running, as it will rebuild at each start.
+
+### Failed to load
+
+Since docker compose update 2.16.0, The environment won't start.
+
+You'll have a similar message :
+
+```
+Failed to load /home/user/Documents/coopengo/env/back.env: open /home/user/Documents/coopengo/env/back.env: no such file or directory
+```
+
+To fix this error, you will have to update the coog-docker project with the `git pull` command.

--- a/bin/configure
+++ b/bin/configure
@@ -137,6 +137,7 @@ set_services () {
     fi
 
     echo "COMPOSE_FILE=$SERVICES" >> "$BASE_PATH/.env"
+    echo "BASE_PATH=$BASE_PATH" >> "$BASE_PATH/.env"
     echo ""
 }
 

--- a/compose/back/common.yml
+++ b/compose/back/common.yml
@@ -2,8 +2,8 @@ services:
   back-common:
     image: ${IMAGE_REGISTRY_COOG:?}/${IMAGE_NAME_COOG:?}:${IMAGE_VERSION_COOG:?}
     env_file:
-      # For some reason, we need to specify a relative path here
-      - ../../env/back.env
+      # The file is called from others .yml file, we must set full path
+      - ${BASE_PATH}/env/back.env
     entrypoint: ['ep']
     environment:
       - LOG_LEVEL=${COOG_LOG_LEVEL:?}


### PR DESCRIPTION
Last docker compose version (v2.16.0) broke the configuration generation. 

The command `docker compose convert` became `docker compose config`

This PR fix the issue and make the script works for versions before 2.16 too.

The fix has been tested for docker compose v2.16.0 and v2.11.2