### PR TITLE
celery-indexes: Depend on coog rather than postgres

### DIFF
--- a/compose/back/celery_indexes.yml
+++ b/compose/back/celery_indexes.yml
@@ -5,7 +5,7 @@ services:
       service: back-common
     command: ["celery_maintenance"]
     depends_on:
-      postgres:
+      coog:
         condition: service_started
       rabbitmq:
         condition: service_started


### PR DESCRIPTION
Issue link: [https://coopengo.atlassian.net/browse/PCLAS-1257](https://coopengo.atlassian.net/browse/PCLAS-1257)

Fix PCLAS-1257